### PR TITLE
feat: enhance Owner registration with validation for existing IDs and…

### DIFF
--- a/backend/src/contexts/owner/infra/persistence/MemoryOwnerRepository.ts
+++ b/backend/src/contexts/owner/infra/persistence/MemoryOwnerRepository.ts
@@ -10,6 +10,17 @@ export class MemoryOwnerRepository implements OwnerRepository {
   }
 
   async save(owner: Owner): Promise<void> {
+    // Verify if Owner id already exists
+    const existingOwner = await this.findById(owner.id);
+    if (existingOwner) {
+      throw new Error('Owner id already exists');
+    }
+    // Verify if email already exists
+    for (const existingOwner of this.owners.values()) {
+      if (existingOwner.email === owner.email) {
+        throw new Error('Email already exists');
+      }
+    }
     this.owners.set(owner.id.getValue(), owner);
   }
 }

--- a/backend/src/contexts/owner/infra/persistence/PrismaOwnerRepository.ts
+++ b/backend/src/contexts/owner/infra/persistence/PrismaOwnerRepository.ts
@@ -27,6 +27,30 @@ export class PrismaOwnerRepository implements OwnerRepository {
   }
 
   async save(owner: Owner): Promise<void> {
-    
+    // Verify if the id already exists
+    const existingOwner = await this.findById(owner.id);
+    if (existingOwner) {
+      throw new Error('Owner id already exists');
+    }
+    // Verify if the email already exists
+    const existingEmail = await prisma.user.findUnique({
+      where: { email: owner.email }
+    });
+    if (existingEmail) {
+      throw new Error('Email already exists');
+    }
+    // If it doesn't exist, create the User and the Owner
+    await prisma.user.create({
+      data: {
+        id: owner.id.getValue(),
+        name: owner.name,
+        last_name: owner.lastName,
+        email: owner.email,
+        type: 'owner',
+        owner: {
+          create: {}
+        }
+      }
+    });
   }
 }

--- a/backend/src/contexts/owner/tests/app/commands/registerOwner/RegisterOwnerCommandHandler.test.ts
+++ b/backend/src/contexts/owner/tests/app/commands/registerOwner/RegisterOwnerCommandHandler.test.ts
@@ -30,4 +30,23 @@ describe('RegisterOwnerCommandHandler', () => {
     expect(owner?.email).toBe('marc@email.com');
     expect(owner?.petIds).toEqual([]);
   });
+
+  it('should throw error if email already exists', async () => {
+    const command1 = new RegisterOwnerCommand(1, 'Marc', 'Smith', 'marc@email.com');
+    const command2 = new RegisterOwnerCommand(2, 'John', 'Doe', 'marc@email.com');
+
+    await handler.execute(command1);
+
+    await expect(handler.execute(command2)).rejects.toThrow('Email already exists');
+  });
+
+  it('should throw error if Owner id already exists', async () => {
+    const command1 = new RegisterOwnerCommand(1, 'Marc', 'Smith', 'marc@email.com');
+    const command2 = new RegisterOwnerCommand(1, 'John', 'Doe', 'john@email.com');
+
+    await handler.execute(command1);
+
+    await expect(handler.execute(command2)).rejects.toThrow('Owner id already exists');
+  });
+
 });


### PR DESCRIPTION
This pull request introduces important validation checks to prevent duplicate owner registrations, ensuring both owner IDs and emails are unique in the system. These changes are applied to both in-memory and Prisma-based repositories, and new tests have been added to verify this behavior.

**Validation logic improvements:**

* Added checks in `MemoryOwnerRepository` to throw errors if an owner with the same ID or email already exists when saving a new owner.
* Updated `PrismaOwnerRepository` to verify uniqueness of both owner ID and email before creating a new owner, throwing appropriate errors if duplicates are found.

**Testing enhancements:**

* Added tests in `RegisterOwnerCommandHandler.test.ts` to ensure errors are thrown when attempting to register an owner with a duplicate email or ID.