### PR TITLE
fix: Add the missing dependency installation to the Docker build

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,3 +1,16 @@
 FROM node:22-alpine
 WORKDIR /app
+
+# Copy only package.json and package-lock.json first
+COPY package*.json ./
+
+# Install dependencies (cached if package files don't change)
+RUN npm install
+
+# Copy the rest of the code
+COPY . .
+
+# Expose the port
+EXPOSE 3000
+
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
The Docker API container could not be started due to 'TSX not found'.

This pull request adds the missing dependency installation to the Docker API container.