### PR TITLE
feat: implement delete owner functionality with command pattern and r…

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -60,18 +60,19 @@ model User {
   volunteer Volunteer?
 
   @@index([type])
+  @@index([email])
 }
 
 model Owner {
   id   Int  @id
-  user User @relation(fields: [id], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  user User @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
   pets Pet[]
 }
 
 model Volunteer {
   id          Int   @id
   description String
-  user        User  @relation(fields: [id], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  user        User  @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }
 
 model Pet {

--- a/backend/src/contexts/owner/app/commands/delete/DeleteOwnerCommand.ts
+++ b/backend/src/contexts/owner/app/commands/delete/DeleteOwnerCommand.ts
@@ -1,0 +1,6 @@
+export class DeleteOwnerCommand {
+  constructor(
+    public readonly ownerId: number,
+    public readonly requestingUserId: number
+  ) {}
+}

--- a/backend/src/contexts/owner/app/commands/delete/DeleteOwnerCommandHandler.ts
+++ b/backend/src/contexts/owner/app/commands/delete/DeleteOwnerCommandHandler.ts
@@ -1,0 +1,29 @@
+import { DeleteOwnerCommand } from './DeleteOwnerCommand.js';
+import { OwnerRepository } from '../../../domain/repositories/OwnerRepository.js';
+import { OwnerId } from '../../../domain/value-objects/OwnerId.js';
+
+export class DeleteOwnerCommandHandler {
+  constructor(private readonly ownerRepository: OwnerRepository) {}
+
+  async execute(command: DeleteOwnerCommand): Promise<{ message: string }> {
+    const ownerId = new OwnerId(command.ownerId);
+    
+    // Verify that the owner exists
+    const owner = await this.ownerRepository.findById(ownerId);
+    
+    if (!owner) {
+      throw new Error('Owner not found');
+    }
+
+    // Only the owner can delete themselves
+    if (owner.id.getValue() !== command.requestingUserId) {
+      throw new Error('You can only delete your own account');
+    }
+
+    await this.ownerRepository.delete(ownerId);
+
+    return {
+      message: 'Owner account and all related data successfully deleted'
+    };
+  }
+}

--- a/backend/src/contexts/owner/domain/repositories/OwnerRepository.ts
+++ b/backend/src/contexts/owner/domain/repositories/OwnerRepository.ts
@@ -4,4 +4,5 @@ import { OwnerId } from '../value-objects/OwnerId.js';
 export interface OwnerRepository {
   findById(id: OwnerId): Promise<Owner | null>;
   save(owner: Owner): Promise<void>;
+  delete(id: OwnerId): Promise<void>;
 }

--- a/backend/src/contexts/owner/infra/controllers/DeleteOwnerController.ts
+++ b/backend/src/contexts/owner/infra/controllers/DeleteOwnerController.ts
@@ -1,0 +1,41 @@
+import { Response } from 'express';
+import { DeleteOwnerCommand } from '../../app/commands/delete/DeleteOwnerCommand.js';
+import { DeleteOwnerCommandHandler } from '../../app/commands/delete/DeleteOwnerCommandHandler.js';
+import { AuthenticatedRequest } from '../../../auth/infra/middleware/JwtMiddleware.js';
+
+export class DeleteOwnerController {
+  constructor(private readonly commandHandler: DeleteOwnerCommandHandler) {}
+
+  async handle(request: AuthenticatedRequest, response: Response): Promise<void> {
+    try {
+      const ownerId = parseInt(request.params.id);
+      const requestingUserId = request.user!.userId;
+
+      if (isNaN(ownerId)) {
+        response.status(400).json({ 
+          error: 'Invalid owner ID' 
+        });
+        return;
+      }
+
+      const command = new DeleteOwnerCommand(ownerId, requestingUserId);
+
+      const result = await this.commandHandler.execute(command);
+
+      response.status(200).json(result);
+
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('not found')) {
+          response.status(404).json({ error: error.message });
+        } else if (error.message.includes('can only delete your own')) {
+          response.status(403).json({ error: error.message });
+        } else {
+          response.status(400).json({ error: error.message });
+        }
+      } else {
+        response.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  }
+}

--- a/backend/src/contexts/owner/infra/persistence/MemoryOwnerRepository.ts
+++ b/backend/src/contexts/owner/infra/persistence/MemoryOwnerRepository.ts
@@ -23,4 +23,8 @@ export class MemoryOwnerRepository implements OwnerRepository {
     }
     this.owners.set(owner.id.getValue(), owner);
   }
+
+  async delete(id: OwnerId): Promise<void> {
+    this.owners.delete(id.getValue());
+  }
 }

--- a/backend/src/contexts/owner/infra/persistence/PrismaOwnerRepository.ts
+++ b/backend/src/contexts/owner/infra/persistence/PrismaOwnerRepository.ts
@@ -55,4 +55,10 @@ export class PrismaOwnerRepository implements OwnerRepository {
       }
     });
   }
+
+  async delete(id: OwnerId): Promise<void> {
+    await prisma.user.delete({
+      where: { id: id.getValue() }
+    });
+  }
 }

--- a/backend/src/contexts/owner/tests/app/commands/deleteOwner/DeleteOwnerCommandHandler.test.ts
+++ b/backend/src/contexts/owner/tests/app/commands/deleteOwner/DeleteOwnerCommandHandler.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DeleteOwnerCommandHandler } from '../../../../app/commands/delete/DeleteOwnerCommandHandler.js';
+import { DeleteOwnerCommand } from '../../../../app/commands/delete/DeleteOwnerCommand.js';
+import { OwnerRepository } from '../../../../domain/repositories/OwnerRepository.js';
+import { Owner } from '../../../../domain/entities/Owner.js';
+import { OwnerId } from '../../../../domain/value-objects/OwnerId.js';
+
+describe('DeleteOwnerCommandHandler', () => {
+  let handler: DeleteOwnerCommandHandler;
+  let mockRepository: OwnerRepository;
+
+  beforeEach(() => {
+    mockRepository = {
+      findById: vi.fn(),
+      save: vi.fn(),
+      delete: vi.fn()
+    };
+    handler = new DeleteOwnerCommandHandler(mockRepository);
+  });
+
+  describe('execute', () => {
+    it('should delete owner successfully when owner exists and user is authorized', async () => {
+      // Arrange
+      const ownerId = 1;
+      const requestingUserId = 1;
+      const command = new DeleteOwnerCommand(ownerId, requestingUserId);
+      
+      const mockOwner = await Owner.create(
+        new OwnerId(1),
+        'John',
+        'Doe',
+        'john@example.com',
+        'password123'
+      );
+
+      vi.mocked(mockRepository.findById).mockResolvedValue(mockOwner);
+      vi.mocked(mockRepository.delete).mockResolvedValue();
+
+      const result = await handler.execute(command);
+
+      expect(mockRepository.findById).toHaveBeenCalledWith(new OwnerId(ownerId));
+      expect(mockRepository.delete).toHaveBeenCalledWith(new OwnerId(ownerId));
+      expect(result).toEqual({
+        message: 'Owner account and all related data successfully deleted'
+      });
+    });
+
+    it('should throw error when owner does not exist', async () => {
+      const ownerId = 999;
+      const requestingUserId = 1;
+      const command = new DeleteOwnerCommand(ownerId, requestingUserId);
+
+      vi.mocked(mockRepository.findById).mockResolvedValue(null);
+
+      await expect(handler.execute(command)).rejects.toThrow('Owner not found');
+      expect(mockRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when user tries to delete someone else account', async () => {
+      const ownerId = 1;
+      const requestingUserId = 2;
+      const command = new DeleteOwnerCommand(ownerId, requestingUserId);
+      
+      const mockOwner = await Owner.create(
+        new OwnerId(1),
+        'John',
+        'Doe',
+        'john@example.com',
+        'password123'
+      );
+
+      vi.mocked(mockRepository.findById).mockResolvedValue(mockOwner);
+
+      await expect(handler.execute(command)).rejects.toThrow('You can only delete your own account');
+      expect(mockRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('should propagate repository errors', async () => {
+      const ownerId = 1;
+      const requestingUserId = 1;
+      const command = new DeleteOwnerCommand(ownerId, requestingUserId);
+      
+      const mockOwner = await Owner.create(
+        new OwnerId(1),
+        'John',
+        'Doe',
+        'john@example.com',
+        'password123'
+      );
+
+      vi.mocked(mockRepository.findById).mockResolvedValue(mockOwner);
+      vi.mocked(mockRepository.delete).mockRejectedValue(new Error('Database error'));
+
+      await expect(handler.execute(command)).rejects.toThrow('Database error');
+    });
+  });
+});

--- a/backend/src/routes/ownerRoutes.ts
+++ b/backend/src/routes/ownerRoutes.ts
@@ -1,7 +1,10 @@
 import { Router } from 'express';
 import { RegisterOwnerController } from '../contexts/owner/infra/controllers/RegisterOwnerController.js';
 import { RegisterOwnerCommandHandler } from '../contexts/owner/app/commands/registerOwner/RegisterOwnerCommandHandler.js';
+import { DeleteOwnerController } from '../contexts/owner/infra/controllers/DeleteOwnerController.js';
+import { DeleteOwnerCommandHandler } from '../contexts/owner/app/commands/delete/DeleteOwnerCommandHandler.js';
 import { PrismaOwnerRepository } from '../contexts/owner/infra/persistence/PrismaOwnerRepository.js';
+import { JwtMiddleware } from '../contexts/auth/infra/middleware/JwtMiddleware.js';
 
 export function createOwnerRoutes(): Router {
   console.log('Creating owner routes...');
@@ -10,14 +13,26 @@ export function createOwnerRoutes(): Router {
   // Dependency injection setup
   console.log('Setting up dependencies...');
   const ownerRepository = new PrismaOwnerRepository();
-  const commandHandler = new RegisterOwnerCommandHandler(ownerRepository);
-  const controller = new RegisterOwnerController(commandHandler);
+  
+  // Register dependencies
+  const registerCommandHandler = new RegisterOwnerCommandHandler(ownerRepository);
+  const registerController = new RegisterOwnerController(registerCommandHandler);
+  
+  // Delete dependencies
+  const deleteCommandHandler = new DeleteOwnerCommandHandler(ownerRepository);
+  const deleteController = new DeleteOwnerController(deleteCommandHandler);
 
   // Routes
   console.log('Registering POST /register route...');
   router.post('/register', async (req, res) => {
-    console.log('POST /register endpoint hit!');
-    await controller.handle(req, res);
+    console.log('POST /register endpoint');
+    await registerController.handle(req, res);
+  });
+
+  console.log('Registering DELETE /:id route...');
+  router.delete('/:id', ...JwtMiddleware.requireOwner(), async (req, res) => {
+    console.log('DELETE /:id endpoint');
+    await deleteController.handle(req, res);
   });
 
   return router;

--- a/backend/tests/http/delete-owner-test.http
+++ b/backend/tests/http/delete-owner-test.http
@@ -1,0 +1,51 @@
+# Delete Owner Test
+
+# NOTE: Update @jwt_token with a valid token from login
+@jwt_token = token
+
+### Step 1: Register a new owner to delete
+POST http://localhost:3000/api/owners/register
+Content-Type: application/json
+
+{
+  "id": 999,
+  "name": "Test",
+  "lastName": "Delete",
+  "email": "delete.test@example.com",
+  "password": "password123"
+}
+
+### Step 2: Login with the test owner to get token
+POST http://localhost:3000/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "delete.test@example.com",
+  "password": "password123"
+}
+
+###
+
+### Step 3: Delete the owner
+DELETE http://localhost:3000/api/owners/999
+Authorization: Bearer {{jwt_token}}
+Content-Type: application/json
+
+###
+
+### Step 4: Try to login again
+POST http://localhost:3000/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "delete.test@example.com",
+  "password": "password123"
+}
+
+###
+
+### Step 5: Try to delete someone else's account (should fail with 403)
+DELETE http://localhost:3000/api/owners/1
+Authorization: Bearer {{jwt_token}}
+Content-Type: application/json
+


### PR DESCRIPTION
This pull request implements the ability for an owner to delete their own account, including all related data, through a secure API endpoint. It introduces the necessary command, handler, controller, persistence methods, and tests, while also updating the database schema to ensure proper cascading deletes. The changes ensure only the authenticated owner can perform the deletion, and robustly handle error scenarios.

**Owner Deletion Feature:**

* Added `DeleteOwnerCommand` and `DeleteOwnerCommandHandler` to encapsulate and handle the logic for deleting an owner, ensuring only the owner can delete their own account and providing clear error messages for unauthorized or invalid requests. [[1]](diffhunk://#diff-d43e409a1a7b1bd234996e067cc403833ee12d04e9c55b02b23b05c5ef28c655R1-R6) [[2]](diffhunk://#diff-0de12958434248697347d7f1e76e68d2628cb7b5ecfe5b5eeb0ae1f0c9557d2fR1-R29)
* Added `DeleteOwnerController` to expose a new DELETE `/owners/:id` endpoint, handling authentication, request validation, and error responses. [[1]](diffhunk://#diff-cd329af2577710a7ee3acdef7bac9e7f2682c5505acacd49a40fd945b57fe129R1-R41) [[2]](diffhunk://#diff-f6e5f4c1c076b8c2b7cbb4002634655512392ecfa11c5d2415137917ed514141R4-R7) [[3]](diffhunk://#diff-f6e5f4c1c076b8c2b7cbb4002634655512392ecfa11c5d2415137917ed514141L13-R35)
* Updated the `OwnerRepository` interface and both `MemoryOwnerRepository` and `PrismaOwnerRepository` implementations to support deleting owners by ID. [[1]](diffhunk://#diff-04aa4870b4a71aae0ffbf930d9fe50deb3f423947769b4174799723cb6af3b98R7) [[2]](diffhunk://#diff-47ca12a26a6c9efd9f7f4b47d49cc72bf6046c9a26b5600d76220d6f5625715bR26-R29) [[3]](diffhunk://#diff-80c559bb525269ff9a8c1ef83e8248b787a1d0f7a21c2dad14743de09a8742aeR58-R63)

**Database Schema Updates:**

* Modified `schema.prisma` to set `onDelete: Cascade` for owner and volunteer relations, ensuring that deleting a user also deletes related owner/volunteer records, and added an index on the `email` field for efficient lookups.

**Testing and Documentation:**

* Added comprehensive unit tests for the `DeleteOwnerCommandHandler`, covering successful deletion, not found, unauthorized deletion, and repository errors.
* Added an HTTP integration test script demonstrating the full owner deletion flow, including registration, authentication, deletion, and validation of access post-deletion.