### PR TITLE
chore: Add database seeders

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,13 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
     "prisma:studio": "prisma studio",
-    "prisma:status": "prisma migrate status"
+    "prisma:status": "prisma migrate status",
+    "db:seed": "tsx src/db/seed.ts",
+    "db:reset": "prisma db push --force-reset && npm run db:seed",
+    "db:migrate:dev": "prisma migrate dev && npm run db:seed"
+  },
+    "prisma": {
+    "seed": "tsx src/db/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.14.0",

--- a/backend/src/db/seed.ts
+++ b/backend/src/db/seed.ts
@@ -1,0 +1,55 @@
+import { PrismaClient } from '@prisma/client';
+import { seedUsers } from './seeds/userSeeder.js';
+import { seedProcedureSchedules } from './seeds/procedureScheduleSeeder.js';
+import { seedPets } from './seeds/petSeeder.js';
+import { seedCheckups } from './seeds/checkupSeeder.js';
+import { seedAppointments } from './seeds/appointmentSeeder.js';
+
+const prisma = new PrismaClient();
+
+async function main() {
+    console.log('🌱 Starting database seeding...');
+
+    try {
+        // Clear existing data (in correct order to respect foreign keys)
+        await prisma.checkup.deleteMany();
+        await prisma.appointment.deleteMany();
+        await prisma.pet.deleteMany();
+        await prisma.procedureSchedule.deleteMany();
+        await prisma.owner.deleteMany();
+        await prisma.volunteer.deleteMany();
+        await prisma.user.deleteMany();
+
+        console.log('🗑️ Cleared existing data');
+
+        // Seed in correct order (respecting foreign keys)
+        await seedUsers(prisma);
+        console.log('👥 Users seeded');
+
+        await seedProcedureSchedules(prisma);
+        console.log('💉 Procedure schedules seeded');
+
+        await seedPets(prisma);
+        console.log('🐕 Pets seeded');
+
+        await seedCheckups(prisma);
+        console.log('🩺 Checkups seeded');
+
+        await seedAppointments(prisma);
+        console.log('📅 Appointments seeded');
+
+        console.log('✅ Database seeding completed successfully!');
+    } catch (error) {
+        console.error('❌ Error during seeding:', error);
+        throw error;
+    }
+}
+
+main()
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/backend/src/db/seeds/appointmentSeeder.ts
+++ b/backend/src/db/seeds/appointmentSeeder.ts
@@ -1,0 +1,81 @@
+import { PrismaClient, AppointmentReason } from '@prisma/client';
+
+export async function seedAppointments(prisma: PrismaClient) {
+    const pets = await prisma.pet.findMany();
+
+    if (pets.length === 0) {
+        throw new Error('No pets found. Run pet seeder first.');
+    }
+
+    const reasons: AppointmentReason[] = [
+        'VACCINATION',
+        'GENERAL_CHECKUP',
+        'ANTI_PARASITIC_PRESCRIPTION',
+        'OPERATION',
+        'OTHERS'
+    ];
+
+    const appointments = [];
+
+    for (const pet of pets) {
+        // Create 1-3 appointments per pet (some future, some past)
+        const appointmentCount = Math.floor(Math.random() * 3) + 1;
+
+        for (let i = 0; i < appointmentCount; i++) {
+            const appointmentDate = new Date();
+
+            // Mix of past and future appointments
+            if (i % 2 === 0) {
+                // Past appointments
+                appointmentDate.setDate(appointmentDate.getDate() - Math.floor(Math.random() * 90));
+            } else {
+                // Future appointments
+                appointmentDate.setDate(appointmentDate.getDate() + Math.floor(Math.random() * 60) + 1);
+            }
+
+            const reason = reasons[Math.floor(Math.random() * reasons.length)];
+            const notes = generateAppointmentNotes(pet, reason, appointmentDate);
+
+            const appointment = await prisma.appointment.create({
+                data: {
+                    pet_id: pet.id,
+                    date: appointmentDate,
+                    reason: reason,
+                    notes: notes
+                }
+            });
+
+            appointments.push(appointment);
+        }
+    }
+
+    return appointments;
+}
+
+function generateAppointmentNotes(pet: any, reason: AppointmentReason, date: Date): string {
+    const isPast = date < new Date();
+
+    const notesByReason = {
+        VACCINATION: isPast
+            ? `Vacunación completada para ${pet.name}. Próxima dosis programada según calendario.`
+            : `Cita programada para vacunación de ${pet.name}. Traer cartilla sanitaria.`,
+
+        GENERAL_CHECKUP: isPast
+            ? `Revisión general completada. ${pet.name} en buen estado de salud.`
+            : `Cita de revisión general para ${pet.name}. Chequeo completo programado.`,
+
+        ANTI_PARASITIC_PRESCRIPTION: isPast
+            ? `Tratamiento antiparasitario administrado a ${pet.name}. Efectivo y bien tolerado.`
+            : `Cita para tratamiento antiparasitario de ${pet.name}. Ayuno de 4 horas previo.`,
+
+        OPERATION: isPast
+            ? `Intervención quirúrgica realizada exitosamente en ${pet.name}. Recuperación satisfactoria.`
+            : `Cirugía programada para ${pet.name}. Pre-operatorio completo requerido.`,
+
+        OTHERS: isPast
+            ? `Consulta específica atendida para ${pet.name}. Tratamiento prescrito según necesidades.`
+            : `Cita programada para consulta específica de ${pet.name}. Detalles a evaluar.`
+    };
+
+    return notesByReason[reason];
+}

--- a/backend/src/db/seeds/checkupSeeder.ts
+++ b/backend/src/db/seeds/checkupSeeder.ts
@@ -1,0 +1,68 @@
+import { PrismaClient } from '@prisma/client';
+
+export async function seedCheckups(prisma: PrismaClient) {
+    const pets = await prisma.pet.findMany();
+    const procedures = await prisma.procedureSchedule.findMany();
+
+    if (pets.length === 0 || procedures.length === 0) {
+        throw new Error('No pets or procedures found. Run pet and procedure seeders first.');
+    }
+
+    const checkups = [];
+
+    for (const pet of pets) {
+        // Filter procedures by animal type
+        const relevantProcedures = procedures.filter(p => p.animal_type === pet.type);
+
+        // Create 2-4 checkups per pet
+        const checkupCount = Math.floor(Math.random() * 3) + 2;
+
+        for (let i = 0; i < checkupCount; i++) {
+            const checkupDate = new Date();
+            checkupDate.setMonth(checkupDate.getMonth() - (i * 2)); // Every 2 months in the past
+
+            // Pick a random relevant procedure
+            const randomProcedure = relevantProcedures[Math.floor(Math.random() * relevantProcedures.length)];
+
+            const notes = generateCheckupNotes(pet, randomProcedure, i);
+
+            const checkup = await prisma.checkup.create({
+                data: {
+                    pet_id: pet.id,
+                    procedure_id: randomProcedure.id,
+                    date: checkupDate,
+                    notes: notes
+                }
+            });
+
+            checkups.push(checkup);
+        }
+    }
+
+    return checkups;
+}
+
+function generateCheckupNotes(pet: any, procedure: any, checkupNumber: number): string {
+    const notes = [
+        `Procedimiento: ${procedure.procedure_name} realizado correctamente en ${pet.name}.`,
+        `${pet.name} mostró buen comportamiento durante el ${procedure.procedure_name}.`,
+        `Control de rutina - ${procedure.procedure_name}. ${pet.name} en excelente estado.`,
+        `${procedure.procedure_name} aplicado sin complicaciones. ${pet.name} tolera bien el tratamiento.`,
+        `Revisión general satisfactoria. ${procedure.procedure_name} completado según protocolo.`
+    ];
+
+    const additionalNotes = [
+        ` Peso estable.`,
+        ` Se recomienda seguimiento en 3 meses.`,
+        ` Propietario informado sobre cuidados posteriores.`,
+        ` Animal reactivo y alerta.`,
+        ` Se observa buen estado general de salud.`,
+        ` Recomendado mantener rutina de ejercicio.`,
+        ` Control de dieta sugerido.`
+    ];
+
+    const baseNote = notes[Math.floor(Math.random() * notes.length)];
+    const extraNote = additionalNotes[Math.floor(Math.random() * additionalNotes.length)];
+
+    return baseNote + extraNote;
+}

--- a/backend/src/db/seeds/petSeeder.ts
+++ b/backend/src/db/seeds/petSeeder.ts
@@ -1,0 +1,173 @@
+import { PrismaClient } from '@prisma/client';
+
+export async function seedPets(prisma: PrismaClient) {
+    const owners = await prisma.owner.findMany({
+        include: { user: true }
+    });
+
+    if (owners.length === 0) {
+        throw new Error('No owners found. Run user seeder first.');
+    }
+
+    const pets = await Promise.all([
+        // Pets para Juan García
+        prisma.pet.create({
+            data: {
+                name: 'Luna',
+                race: 'Golden Retriever',
+                type: 'dog',
+                owner_id: owners[0].id,
+                birth_date: new Date('2022-03-15'),
+                size: 'large',
+                microchip_code: 'ES982000000000001',
+                sex: 'female',
+                has_passport: true,
+                country_of_origin: 'Spain',
+                passport_number: 'ESP001234',
+                notes: 'Muy amigable y activa. Le encanta jugar con otros perros.'
+            }
+        }),
+        prisma.pet.create({
+            data: {
+                name: 'Charlie',
+                race: 'Beagle',
+                type: 'dog',
+                owner_id: owners[0].id,
+                birth_date: new Date('2020-12-03'),
+                size: 'medium',
+                microchip_code: 'ES982000000000002',
+                sex: 'male',
+                has_passport: false,
+                notes: 'Le encanta comer, tendencia al sobrepeso. Necesita dieta controlada.'
+            }
+        }),
+
+        // Pets para María López
+        prisma.pet.create({
+            data: {
+                name: 'Max',
+                race: 'Pastor Alemán',
+                type: 'dog',
+                owner_id: owners[1].id,
+                birth_date: new Date('2021-07-22'),
+                size: 'large',
+                microchip_code: 'ES982000000000003',
+                sex: 'male',
+                has_passport: false,
+                notes: 'Perro guardián muy inteligente. Necesita ejercicio intenso diario.'
+            }
+        }),
+        prisma.pet.create({
+            data: {
+                name: 'Sophie',
+                race: 'Hurón Doméstico',
+                type: 'ferret',
+                owner_id: owners[1].id,
+                birth_date: new Date('2023-05-20'),
+                size: 'small',
+                microchip_code: 'ES982000000000004',
+                sex: 'female',
+                has_passport: false,
+                notes: 'Muy juguetona y curiosa. Requiere vigilancia constante.'
+            }
+        }),
+
+        // Pets para Carlos Rodríguez
+        prisma.pet.create({
+            data: {
+                name: 'Mia',
+                race: 'Siamés',
+                type: 'cat',
+                owner_id: owners[2].id,
+                birth_date: new Date('2023-01-10'),
+                size: 'small',
+                microchip_code: 'ES982000000000005',
+                sex: 'female',
+                has_passport: true,
+                country_of_origin: 'Thailand',
+                passport_number: 'THA567890',
+                notes: 'Gata muy independiente y vocal. Descendiente de línea tailandesa.'
+            }
+        }),
+        prisma.pet.create({
+            data: {
+                name: 'Chloe',
+                race: 'Persa',
+                type: 'cat',
+                owner_id: owners[2].id,
+                birth_date: new Date('2021-04-25'),
+                size: 'medium',
+                microchip_code: 'ES982000000000006',
+                sex: 'female',
+                has_passport: false,
+                notes: 'Requiere cepillado diario. Pelo largo, propensa a bolas de pelo.'
+            }
+        }),
+
+        // Pets adicionales distribuidas entre owners
+        prisma.pet.create({
+            data: {
+                name: 'Rocky',
+                race: 'Bulldog Francés',
+                type: 'dog',
+                owner_id: owners[0].id,
+                birth_date: new Date('2022-11-05'),
+                size: 'medium',
+                microchip_code: 'ES982000000000007',
+                sex: 'male',
+                has_passport: false,
+                notes: 'Problemas respiratorios leves típicos de la raza. Evitar ejercicio intenso.'
+            }
+        }),
+        prisma.pet.create({
+            data: {
+                name: 'Bella',
+                race: 'Maine Coon',
+                type: 'cat',
+                owner_id: owners[1].id,
+                birth_date: new Date('2021-09-18'),
+                size: 'large',
+                microchip_code: 'ES982000000000008',
+                sex: 'female',
+                has_passport: true,
+                country_of_origin: 'USA',
+                passport_number: 'USA123456',
+                notes: 'Gata de gran tamaño, muy sociable con otros animales.'
+            }
+        }),
+        prisma.pet.create({
+            data: {
+                name: 'Zeus',
+                race: 'Rottweiler',
+                type: 'dog',
+                owner_id: owners[2].id,
+                birth_date: new Date('2020-06-30'),
+                size: 'large',
+                microchip_code: 'ES982000000000009',
+                sex: 'male',
+                has_passport: true,
+                country_of_origin: 'Germany',
+                passport_number: 'GER789012',
+                notes: 'Muy protector y leal. Entrenamiento en obediencia avanzada.'
+            }
+        }),
+        prisma.pet.create({
+            data: {
+                name: 'Toby',
+                race: 'Labrador Chocolate',
+                type: 'dog',
+                owner_id: owners[0].id,
+                birth_date: new Date('2022-08-14'),
+                size: 'large',
+                microchip_code: 'ES982000000000010',
+                sex: 'male',
+                has_passport: true,
+                country_of_origin: 'Canada',
+                passport_number: 'CAN345678',
+                notes: 'Excelente nadador. Le encanta el agua y recuperar objetos.'
+            }
+        })
+    ]);
+
+    return pets;
+}

--- a/backend/src/db/seeds/procedureScheduleSeeder.ts
+++ b/backend/src/db/seeds/procedureScheduleSeeder.ts
@@ -1,0 +1,109 @@
+import { PrismaClient } from '@prisma/client';
+
+export async function seedProcedureSchedules(prisma: PrismaClient) {
+    const procedures = await Promise.all([
+        // Dog procedures
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'dog',
+                procedure_name: 'Vacuna polivalente',
+                recommended_vaccines_age: 8,
+                notes: 'Primera dosis de vacuna polivalente contra moquillo, hepatitis, parvovirosis'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'dog',
+                procedure_name: 'Vacuna antirrábica',
+                recommended_vaccines_age: 12,
+                notes: 'Vacuna obligatoria contra la rabia'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'dog',
+                procedure_name: 'Desparasitación interna',
+                recommended_vaccines_age: 6,
+                notes: 'Tratamiento contra parásitos intestinales'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'dog',
+                procedure_name: 'Desparasitación externa',
+                recommended_vaccines_age: 8,
+                notes: 'Tratamiento contra pulgas, garrapatas y otros parásitos externos'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'dog',
+                procedure_name: 'Vacuna tos de las perreras',
+                recommended_vaccines_age: 10,
+                notes: 'Protección contra traqueobronquitis infecciosa'
+            }
+        }),
+
+        // Cat procedures
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'cat',
+                procedure_name: 'Vacuna trivalente felina',
+                recommended_vaccines_age: 9,
+                notes: 'Vacuna contra panleucopenia, rinotraqueítis y calicivirus'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'cat',
+                procedure_name: 'Vacuna leucemia felina',
+                recommended_vaccines_age: 12,
+                notes: 'Protección contra el virus de la leucemia felina'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'cat',
+                procedure_name: 'Desparasitación felina',
+                recommended_vaccines_age: 6,
+                notes: 'Tratamiento específico para parásitos en gatos'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'cat',
+                procedure_name: 'Vacuna antirrábica felina',
+                recommended_vaccines_age: 16,
+                notes: 'Vacuna contra la rabia para gatos'
+            }
+        }),
+
+        // Ferret procedures
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'ferret',
+                procedure_name: 'Vacuna moquillo hurón',
+                recommended_vaccines_age: 8,
+                notes: 'Vacuna específica contra moquillo en hurones'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'ferret',
+                procedure_name: 'Vacuna rabia hurón',
+                recommended_vaccines_age: 12,
+                notes: 'Vacuna antirrábica para hurones'
+            }
+        }),
+        prisma.procedureSchedule.create({
+            data: {
+                animal_type: 'ferret',
+                procedure_name: 'Desparasitación hurón',
+                recommended_vaccines_age: 6,
+                notes: 'Tratamiento antiparasitario específico para hurones'
+            }
+        })
+    ]);
+
+    return procedures;
+}

--- a/backend/src/db/seeds/userSeeder.ts
+++ b/backend/src/db/seeds/userSeeder.ts
@@ -1,0 +1,86 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
+
+export async function seedUsers(prisma: PrismaClient) {
+    //password: huellas123
+    const hashedPassword = "$2a$12$LmoCNYhqu6KY1ifSr4pbF.PVzJtwcdpaDisgKn/ZGWYkk4EM..Hk.";
+
+    // Create owners
+    const owners = await Promise.all([
+        prisma.user.create({
+            data: {
+                name: 'Juan',
+                last_name: 'García',
+                email: 'juan@email.com',
+                password: hashedPassword,
+                type: 'owner',
+                owner: {
+                    create: {}
+                }
+            },
+            include: { owner: true }
+        }),
+        prisma.user.create({
+            data: {
+                name: 'María',
+                last_name: 'López',
+                email: 'maria@email.com',
+                password: hashedPassword,
+                type: 'owner',
+                owner: {
+                    create: {}
+                }
+            },
+            include: { owner: true }
+        }),
+        prisma.user.create({
+            data: {
+                name: 'Carlos',
+                last_name: 'Rodríguez',
+                email: 'carlos@email.com',
+                password: hashedPassword,
+                type: 'owner',
+                owner: {
+                    create: {}
+                }
+            },
+            include: { owner: true }
+        })
+    ]);
+
+    // Create volunteers
+    const volunteers = await Promise.all([
+        prisma.user.create({
+            data: {
+                name: 'Ana',
+                last_name: 'Martínez',
+                email: 'ana@volunteer.com',
+                password: hashedPassword,
+                type: 'volunteer',
+                volunteer: {
+                    create: {
+                        description: 'Veterinaria especializada en felinos'
+                    }
+                }
+            },
+            include: { volunteer: true }
+        }),
+        prisma.user.create({
+            data: {
+                name: 'Luis',
+                last_name: 'Sánchez',
+                email: 'luis@volunteer.com',
+                password: hashedPassword,
+                type: 'volunteer',
+                volunteer: {
+                    create: {
+                        description: 'Entrenador canino profesional'
+                    }
+                }
+            },
+            include: { volunteer: true }
+        })
+    ]);
+
+    return { owners, volunteers };
+}


### PR DESCRIPTION
This pull request adds database seeders to load data of the following entities:
- Appointments
- Checkups
- Pets
- Procedures Schedule
- User

The password of the generated users is: `huellas123`

To run the seeders you have to execute the following commands inside of Huellas_api docker container:
-  `npm run db: reset` -> Recreate all existing tables and fill with mock data.

<img width="1077" height="508" alt="Captura de pantalla 2025-08-20 a las 23 58 19" src="https://github.com/user-attachments/assets/1608373a-2d72-420c-b9ce-3018d5860fe7" />
