### PR TITLE
fix: update email in tests for owner registration and login

### DIFF
--- a/backend/src/contexts/owner/infra/persistence/PrismaOwnerRepository.ts
+++ b/backend/src/contexts/owner/infra/persistence/PrismaOwnerRepository.ts
@@ -2,7 +2,6 @@ import { PrismaClient } from '@prisma/client';
 import { OwnerRepository } from '../../domain/repositories/OwnerRepository.js';
 import { Owner } from '../../domain/entities/Owner.js';
 import { OwnerId } from '../../domain/value-objects/OwnerId.js';
-import bcrypt from 'bcrypt';
 
 const prisma = new PrismaClient();
 
@@ -38,16 +37,13 @@ export class PrismaOwnerRepository implements OwnerRepository {
       throw new Error('Owner with this email already exists');
     }
 
-    const hashedPassword = await bcrypt.hash(owner.password, 12);
-
     const result = await prisma.$transaction(async (prisma) => {
-      // Create user first to get the auto-generated ID
       const createdUser = await prisma.user.create({
         data: {
           name: owner.name,
           last_name: owner.lastName,
           email: owner.email,
-          password: hashedPassword,
+          password: owner.password,
           type: 'owner'
         }
       });

--- a/backend/tests/http/auth.http
+++ b/backend/tests/http/auth.http
@@ -5,7 +5,7 @@ POST http://localhost:3000/api/auth/login
 Content-Type: application/json
 
 {
-  "email": "juan.perez@email.com",
+  "email": "juan.perez2@email.com",
   "password": "mySecurePassword123"
 }
 

--- a/backend/tests/http/owners.http
+++ b/backend/tests/http/owners.http
@@ -7,7 +7,7 @@ Content-Type: application/json
 {
   "name": "Juan",
   "lastName": "Pérez",
-  "email": "juan.perez6@email.com",
+  "email": "juan.perez2@email.com",
   "password": "mySecurePassword123"
 }
 


### PR DESCRIPTION
This pull request makes a key change to how owner passwords are handled in the `PrismaOwnerRepository`, removing password hashing before storage. It also updates test data in HTTP test files to use a consistent email address.

Repository logic changes:

* Removed the use of `bcrypt` for hashing passwords before saving them; passwords are now stored in plaintext as provided in the `PrismaOwnerRepository` (`backend/src/contexts/owner/infra/persistence/PrismaOwnerRepository.ts`). [[1]](diffhunk://#diff-80c559bb525269ff9a8c1ef83e8248b787a1d0f7a21c2dad14743de09a8742aeL5) [[2]](diffhunk://#diff-80c559bb525269ff9a8c1ef83e8248b787a1d0f7a21c2dad14743de09a8742aeL41-R46)

Test data updates:

* Changed the email address in the owner creation and login HTTP tests to `juan.perez2@email.com` for consistency (`backend/tests/http/owners.http`, `backend/tests/http/auth.http`). [[1]](diffhunk://#diff-e9eacf3498285b1e53d666f7c39f8ac020be7f1c3b7b6ec1d764cd7700c74f2eL10-R10) [[2]](diffhunk://#diff-bdfe126439aeb59622cc17382f5bb0903cc7c4951e5e22c7352dada1df7b606aL8-R8)