### PR TITLE
feat: add chat and volunteer post models with corresponding tables an…

### DIFF
--- a/backend/prisma/migrations/20250828144157_add_chat_and_volunteer_posts_tables/migration.sql
+++ b/backend/prisma/migrations/20250828144157_add_chat_and_volunteer_posts_tables/migration.sql
@@ -1,0 +1,90 @@
+-- CreateTable
+CREATE TABLE `Conversation` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(191) NULL,
+    `status` ENUM('ACTIVE', 'ARCHIVED', 'CLOSED') NOT NULL DEFAULT 'ACTIVE',
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `created_by` INTEGER NOT NULL,
+
+    INDEX `Conversation_status_idx`(`status`),
+    INDEX `Conversation_created_by_idx`(`created_by`),
+    INDEX `Conversation_created_at_idx`(`created_at`),
+    INDEX `Conversation_updated_at_idx`(`updated_at`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ConversationParticipant` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `conversation_id` INTEGER NOT NULL,
+    `user_id` INTEGER NOT NULL,
+    `joined_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `last_read_at` DATETIME(3) NULL,
+
+    INDEX `ConversationParticipant_conversation_id_idx`(`conversation_id`),
+    INDEX `ConversationParticipant_user_id_idx`(`user_id`),
+    INDEX `ConversationParticipant_joined_at_idx`(`joined_at`),
+    UNIQUE INDEX `ConversationParticipant_conversation_id_user_id_key`(`conversation_id`, `user_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Message` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `conversation_id` INTEGER NOT NULL,
+    `sender_id` INTEGER NOT NULL,
+    `content` TEXT NOT NULL,
+    `type` ENUM('TEXT', 'IMAGE', 'FILE', 'SYSTEM') NOT NULL DEFAULT 'TEXT',
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `edited_at` DATETIME(3) NULL,
+
+    INDEX `Message_conversation_id_idx`(`conversation_id`),
+    INDEX `Message_sender_id_idx`(`sender_id`),
+    INDEX `Message_created_at_idx`(`created_at`),
+    INDEX `Message_conversation_id_created_at_idx`(`conversation_id`, `created_at`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `VolunteerPost` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(191) NOT NULL,
+    `content` TEXT NOT NULL,
+    `author_id` INTEGER NOT NULL,
+    `category` ENUM('GENERAL', 'URGENT', 'EVENT', 'VOLUNTEER_NEEDED', 'ANNOUNCEMENT') NOT NULL DEFAULT 'GENERAL',
+    `status` ENUM('DRAFT', 'PUBLISHED', 'ARCHIVED', 'EXPIRED') NOT NULL DEFAULT 'DRAFT',
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `published_at` DATETIME(3) NULL,
+    `expires_at` DATETIME(3) NULL,
+
+    INDEX `VolunteerPost_author_id_idx`(`author_id`),
+    INDEX `VolunteerPost_category_idx`(`category`),
+    INDEX `VolunteerPost_status_idx`(`status`),
+    INDEX `VolunteerPost_created_at_idx`(`created_at`),
+    INDEX `VolunteerPost_published_at_idx`(`published_at`),
+    INDEX `VolunteerPost_expires_at_idx`(`expires_at`),
+    INDEX `VolunteerPost_category_status_idx`(`category`, `status`),
+    INDEX `VolunteerPost_status_published_at_idx`(`status`, `published_at`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Conversation` ADD CONSTRAINT `Conversation_created_by_fkey` FOREIGN KEY (`created_by`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `ConversationParticipant` ADD CONSTRAINT `ConversationParticipant_conversation_id_fkey` FOREIGN KEY (`conversation_id`) REFERENCES `Conversation`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `ConversationParticipant` ADD CONSTRAINT `ConversationParticipant_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `Message` ADD CONSTRAINT `Message_conversation_id_fkey` FOREIGN KEY (`conversation_id`) REFERENCES `Conversation`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `Message` ADD CONSTRAINT `Message_sender_id_fkey` FOREIGN KEY (`sender_id`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+-- AddForeignKey
+ALTER TABLE `VolunteerPost` ADD CONSTRAINT `VolunteerPost_author_id_fkey` FOREIGN KEY (`author_id`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,6 +41,34 @@ enum AppointmentReason {
   OTHERS
 }
 
+enum ConversationStatus {
+  ACTIVE
+  ARCHIVED
+  CLOSED
+}
+
+enum MessageType {
+  TEXT
+  IMAGE
+  FILE
+  SYSTEM
+}
+
+enum PostStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+  EXPIRED
+}
+
+enum PostCategory {
+  GENERAL
+  URGENT
+  EVENT
+  VOLUNTEER_NEEDED
+  ANNOUNCEMENT
+}
+
 // --- Models ---
 
 model User {
@@ -53,40 +81,48 @@ model User {
   owner     Owner?
   volunteer Volunteer?
 
+  // Chat system relations
+  created_conversations     Conversation[]            @relation("CreatedConversations")
+  conversation_participants ConversationParticipant[]
+  sent_messages             Message[]
+
+  // Volunteer post relations
+  authored_posts VolunteerPost[] @relation("AuthoredPosts")
+
   @@index([type])
   @@index([email])
 }
 
 model Owner {
-  id   Int  @id
-  user User @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  id   Int   @id
+  user User  @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
   pets Pet[]
 }
 
 model Volunteer {
-  id          Int   @id
+  id          Int    @id
   description String
-  user        User  @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  user        User   @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }
 
 model Pet {
-  id               Int      @id @default(autoincrement())
-  name             String
-  race             String
-  type             PetType
-  owner_id         Int
-  birth_date       DateTime @db.Date
-  size             PetSize
-  microchip_code   String   @unique
-  sex              Sex
-  has_passport     Boolean
+  id                Int      @id @default(autoincrement())
+  name              String
+  race              String
+  type              PetType
+  owner_id          Int
+  birth_date        DateTime @db.Date
+  size              PetSize
+  microchip_code    String   @unique
+  sex               Sex
+  has_passport      Boolean
   country_of_origin String?
   passport_number   String?
   notes             String?
 
-  owner         Owner            @relation(fields: [owner_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
-  checkups      Checkup[]
-  appointments  Appointment[]
+  owner        Owner         @relation(fields: [owner_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
+  checkups     Checkup[]
+  appointments Appointment[]
 
   @@index([owner_id])
   @@index([type])
@@ -103,7 +139,7 @@ model Checkup {
   notes        String?
 
   pet       Pet               @relation(fields: [pet_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
-  procedure ProcedureSchedule  @relation(fields: [procedure_id], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  procedure ProcedureSchedule @relation(fields: [procedure_id], references: [id], onDelete: Restrict, onUpdate: Restrict)
 
   @@index([pet_id])
   @@index([procedure_id])
@@ -112,11 +148,11 @@ model Checkup {
 }
 
 model Appointment {
-  id      Int      @id @default(autoincrement())
-  pet_id  Int
-  date    DateTime @db.Date
-  reason  AppointmentReason
-  notes   String?
+  id     Int               @id @default(autoincrement())
+  pet_id Int
+  date   DateTime          @db.Date
+  reason AppointmentReason
+  notes  String?
 
   pet Pet @relation(fields: [pet_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
 
@@ -126,15 +162,92 @@ model Appointment {
 }
 
 model ProcedureSchedule {
-  id                     Int        @id @default(autoincrement())
-  animal_type            PetType
-  procedure_name         String
+  id                       Int     @id @default(autoincrement())
+  animal_type              PetType
+  procedure_name           String
   recommended_vaccines_age Int
-  notes                  String?
+  notes                    String?
 
   checkups Checkup[]
 
+  @@unique([animal_type, procedure_name])
   @@index([animal_type])
   @@index([procedure_name])
-  @@unique([animal_type, procedure_name])
+}
+
+model Conversation {
+  id         Int                @id @default(autoincrement())
+  title      String?
+  status     ConversationStatus @default(ACTIVE)
+  created_at DateTime           @default(now())
+  updated_at DateTime           @updatedAt
+  created_by Int
+
+  creator      User                      @relation("CreatedConversations", fields: [created_by], references: [id], onDelete: Cascade, onUpdate: Restrict)
+  participants ConversationParticipant[]
+  messages     Message[]
+
+  @@index([status])
+  @@index([created_by])
+  @@index([created_at])
+  @@index([updated_at])
+}
+
+model ConversationParticipant {
+  id              Int       @id @default(autoincrement())
+  conversation_id Int
+  user_id         Int
+  joined_at       DateTime  @default(now())
+  last_read_at    DateTime?
+
+  conversation Conversation @relation(fields: [conversation_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
+  user         User         @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
+
+  @@unique([conversation_id, user_id])
+  @@index([conversation_id])
+  @@index([user_id])
+  @@index([joined_at])
+}
+
+model Message {
+  id              Int         @id @default(autoincrement())
+  conversation_id Int
+  sender_id       Int
+  content         String      @db.Text
+  type            MessageType @default(TEXT)
+  created_at      DateTime    @default(now())
+  updated_at      DateTime    @updatedAt
+  edited_at       DateTime?
+
+  conversation Conversation @relation(fields: [conversation_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
+  sender       User         @relation(fields: [sender_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
+
+  @@index([conversation_id])
+  @@index([sender_id])
+  @@index([created_at])
+  @@index([conversation_id, created_at])
+}
+
+model VolunteerPost {
+  id           Int          @id @default(autoincrement())
+  title        String
+  content      String       @db.Text
+  author_id    Int
+  category     PostCategory @default(GENERAL)
+  status       PostStatus   @default(DRAFT)
+  created_at   DateTime     @default(now())
+  updated_at   DateTime     @updatedAt
+  published_at DateTime?
+  expires_at   DateTime?
+
+  author User @relation("AuthoredPosts", fields: [author_id], references: [id], onDelete: Cascade, onUpdate: Restrict)
+
+  @@index([author_id])
+  @@index([category])
+  @@index([status])
+  @@index([created_at])
+  @@index([published_at])
+  @@index([expires_at])
+  @@index([category, status])
+  @@index([status, published_at])
 }


### PR DESCRIPTION
This pull request introduces significant new database structures to support a chat system and volunteer post feature. It adds new tables, enums, and relations for conversations, messages, participants, and volunteer posts, along with the necessary foreign keys and indexes for efficient querying and data integrity.

**Chat System Enhancements:**

* Added new models: `Conversation`, `ConversationParticipant`, and `Message` to support multi-user chat functionality, including message types, conversation statuses, and participant tracking. (`backend/prisma/schema.prisma` [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR173-R252) `backend/prisma/migrations/20250828144157_add_chat_and_volunteer_posts_tables/migration.sql` [[2]](diffhunk://#diff-346379e6e0420af7e7bfb8cd74d3e9cb8143b14fe6acdda692a50aa06a3e4840R1-R90)
* Introduced enums: `ConversationStatus` and `MessageType` for consistent status and type management in conversations and messages. (`backend/prisma/schema.prisma` [backend/prisma/schema.prismaR44-R71](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR44-R71))

**Volunteer Post Feature:**

* Added `VolunteerPost` model with fields for content, category, status, and timing, plus indexes to support various queries. (`backend/prisma/schema.prisma` [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR173-R252) `backend/prisma/migrations/20250828144157_add_chat_and_volunteer_posts_tables/migration.sql` [[2]](diffhunk://#diff-346379e6e0420af7e7bfb8cd74d3e9cb8143b14fe6acdda692a50aa06a3e4840R1-R90)
* Introduced enums: `PostStatus` and `PostCategory` to standardize post categorization and lifecycle. (`backend/prisma/schema.prisma` [backend/prisma/schema.prismaR44-R71](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR44-R71))

**User Model Relations:**

* Updated the `User` model to include relations for authored volunteer posts, created conversations, sent messages, and conversation participation. (`backend/prisma/schema.prisma` [backend/prisma/schema.prismaR84-R91](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR84-R91))

**Database Schema Improvements:**

* Added foreign keys and indexes to all new tables to ensure referential integrity and optimize query performance. (`backend/prisma/migrations/20250828144157_add_chat_and_volunteer_posts_tables/migration.sql` [backend/prisma/migrations/20250828144157_add_chat_and_volunteer_posts_tables/migration.sqlR1-R90](diffhunk://#diff-346379e6e0420af7e7bfb8cd74d3e9cb8143b14fe6acdda692a50aa06a3e4840R1-R90))